### PR TITLE
bugfix: call lookupClassMethod instead

### DIFF
--- a/Example.cpp
+++ b/Example.cpp
@@ -37,7 +37,7 @@ public:
           Selector Sel = SelExpr->getSelector();
           if (const ObjCObjectPointerType *OT = Receiver->getType()->getAs<ObjCObjectPointerType>()) {
             ObjCInterfaceDecl *decl = OT->getInterfaceDecl();
-            if (! decl->lookupInstanceMethod(Sel)) {
+            if (! decl->lookupClassMethod(Sel)) {
               errs() << "Warning: class " << TypeName << " does not implement selector " << Sel.getAsString() << "\n";
               SourceLocation Loc = E->getExprLoc();
               PresumedLoc PLoc = astContext->getSourceManager().getPresumedLoc(Loc);


### PR DESCRIPTION
This compiler tool would check whether `Observer` have method `observerWithTarget:action:` or not. 

But [the post](https://www.objc.io/issues/6-build-tools/compiler/) said "This method starts by looking for message expressions that have `Observer` as the receiver, and`observerWithTarget:action:`as the selector, and then looks at the `target` and checks if the method exists. " Is there something wrong?
